### PR TITLE
fixes bug adding a rental item to a newly created event

### DIFF
--- a/app/features/events/contracts/tmContractDocSvc.js
+++ b/app/features/events/contracts/tmContractDocSvc.js
@@ -83,6 +83,9 @@ function tmContractDocSvc(tmDocFactory, tmIdentity) {
         quantity: 0,
         price: 0
       }
+      if(this.doc.rentalItems == undefined) {
+          this.doc.rentalItems = []; //object wasn't properly initialized...
+      }
       this.doc.rentalItems.push(itemToAdd);
     }
     


### PR DESCRIPTION
fixes bug where adding a rental item to a newly created event will throw an undefined error.